### PR TITLE
dynamic routing #1

### DIFF
--- a/app.js
+++ b/app.js
@@ -66,6 +66,7 @@ app.use(testmw);
 ///// User Defined Routes ////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////
 var team = require('./lib/team.js');
+var user_profile = require('./lib/user_profile.js');
 
 app.get('/', (req, res) => {
   var result = team.all();
@@ -161,6 +162,17 @@ else {
   }
 }
 
+});
+
+app.get('/:uuid', (req, res) => {
+  var result = user_profile.fetch(req.params.uuid);
+  if(!result.success) {
+    notFound404(req, res);
+  } else {
+    res.render('a-user-id', {
+      message: result.uuid
+    })
+  }
 });
 
 //////////////////////////////////////////////////////////////////////

--- a/lib/user_profile.js
+++ b/lib/user_profile.js
@@ -1,0 +1,26 @@
+function result(success, message, uuid) {
+	return {
+		success: success,
+		message: message,
+		uuid: uuid
+	};
+}
+
+function find(uuid){
+	//right now this just echos back the uuid that was searched for. 
+	//TODO: make this search the database and return the entry
+	return uuid;
+}
+
+function fetch(uuid) {
+	if(typeof(uuid) != 'string'){
+		return result(false, "Error: not a string. Usage: fetch(uuid) where uuid is the unique user id as a String", '');
+	}
+	var found = find(uuid); //found will be a *copy* of the users member object, because find returns a copy, not the original.
+	if(found === null){
+		return result(false, 'user not found', '');
+	}
+	return result(true, 'user found', found);
+}
+
+exports.fetch = fetch;


### PR DESCRIPTION
This adds a catch-all dynamic route at the bottom of the routes. If a url didn't match on any of the other routes, it will then match on this one. This route takes the url and passes it to the fetch function of the user_profile library. The fetch function in turn passes it to the find function. The find function will need to be written to search the database and return what it finds. What it gets back from find, fetch wraps in a result, and returns to the route handler for rendering.

Currently, find just echos back the uuid it was asked to search for, so ultimately a 'a-user-id' templlate is rendered with the url that was entered as the {{message}}. Try entering localhost:3000/kittens. You should see a user page with the word kittens in it.
